### PR TITLE
Added an error message to the test helpers assert_async method

### DIFF
--- a/lib/sinatra/async/test.rb
+++ b/lib/sinatra/async/test.rb
@@ -66,7 +66,7 @@ class Sinatra::Async::Test
     end
 
     def assert_async
-      assert last_response.async?
+      assert last_response.async?, "response not asynchronous. expected a status of -1 got #{last_response.status}"
     end
 
     # Simulate a user closing the connection before a response is sent.


### PR DESCRIPTION
Hi,

I've been using async_sinatra and the test helpers and have seen the assert_async fail a few times and thought it needed a better error message.

Also, what do you think about changing this to a raise to match the other failures? If you use RSpec you have to include the Test::Unit assertions to get the assert to work.
