### PR TITLE
In latest version of sinatra options is now settings

### DIFF
--- a/lib/sinatra/async/test.rb
+++ b/lib/sinatra/async/test.rb
@@ -78,7 +78,7 @@ class Sinatra::Async::Test
     # Executes the pending asynchronous blocks, required for the
     # aget/apost/etc blocks to run.
     def async_continue
-      while b = app.options.async_schedules.shift
+      while b = app.settings.async_schedules.shift
         b.call
       end
     end


### PR DESCRIPTION
In latest version of sinatra, options is now settings and options is deprecated; See:

https://github.com/sinatra/sinatra/blob/master/lib/sinatra/base.rb#L672

Also when app is a constant e.g. Sinatra::App using options breaks tests.
Changing this to settings should fix this.

I couldn't get the test suite to run so let me know if theres any issues with this.
