### PR TITLE
Correctly send response error if show_exceptions is enabled.

### DIFF
--- a/lib/sinatra/async.rb
+++ b/lib/sinatra/async.rb
@@ -132,9 +132,9 @@ module Sinatra #:nodoc:
         if settings.show_exceptions?
           printer = Sinatra::ShowExceptions.new(proc{ raise boom })
           s, h, b = printer.call(request.env)
-          response.status = s
-          response.headers.replace(h)
-          response.body = b
+          request.env['async.callback'][
+            [s, h, b]
+          ]
         else
           body(handle_exception!(boom))
         end


### PR DESCRIPTION
Hi,

When we are in development mode and show_exceptions is enabled, the error are not sent to the user.
