### PR TITLE
Show the full stack trace on error

### DIFF
--- a/lib/sinatra/async.rb
+++ b/lib/sinatra/async.rb
@@ -135,6 +135,7 @@ module Sinatra #:nodoc:
           response.status = s
           response.headers.replace(h)
           response.body = b
+          body(response.body)
         else
           body(handle_exception!(boom))
         end


### PR DESCRIPTION
When setting the `show_exceptions` to `true`, the `async_handle_exception` would hang b/c `body` wasn't called.
