### PR TITLE
Added custom asynchronous exception handling support

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -34,6 +34,10 @@ A quick example:
      EM.add_timer(n.to_i) { body { "delayed for #{n} seconds" } }
    end
 
+   aerror do |e|
+     # do something with e: airbrake, etc...
+     body e.message
+   end
  end
 
 See Sinatra::Async for more details.

--- a/async_sinatra.gemspec
+++ b/async_sinatra.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["raggi"]
-  s.cert_chain = ["/Users/raggi/.gem/gem-public_cert.pem"]
+  #s.cert_chain = ["/Users/raggi/.gem/gem-public_cert.pem"]
   s.date = %q{2011-03-08}
   s.description = %q{A Sinatra plugin to provide convenience whilst performing asynchronous
 responses inside of the Sinatra framework running under async webservers.
@@ -27,7 +27,7 @@ Currently, supporting servers include:
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{libraggi}
   s.rubygems_version = %q{1.6.0}
-  s.signing_key = %q{/Users/raggi/.gem/gem-private_key.pem}
+  #s.signing_key = %q{/Users/raggi/.gem/gem-private_key.pem}
   s.summary = %q{A Sinatra plugin to provide convenience whilst performing asynchronous responses inside of the Sinatra framework running under async webservers}
   s.test_files = ["test/test_async.rb"]
 

--- a/lib/sinatra/async.rb
+++ b/lib/sinatra/async.rb
@@ -59,6 +59,10 @@ module Sinatra #:nodoc:
     # See #aget
     def aoptions(path, opts={}, &bk); aroute 'OPTIONS', path, opts, &bk; end
 
+    def aerror(&block)
+      define_method :aerror, &block
+    end
+
     private
     def aroute(verb, path, opts = {}, &block) #:nodoc:
       method = :"A#{verb} #{path} #{opts.hash}"
@@ -129,7 +133,9 @@ module Sinatra #:nodoc:
       def async_handle_exception
         yield
       rescue ::Exception => boom
-        if settings.show_exceptions?
+        if respond_to? :aerror
+          aerror boom
+        elsif settings.show_exceptions?
           printer = Sinatra::ShowExceptions.new(proc{ raise boom })
           s, h, b = printer.call(request.env)
           response.status = s

--- a/lib/sinatra/async/test.rb
+++ b/lib/sinatra/async/test.rb
@@ -1,4 +1,4 @@
-require 'sinatra/async'
+require File.join File.dirname(__FILE__), "../async"
 require 'rack/test'
 
 class Rack::MockResponse
@@ -78,7 +78,7 @@ class Sinatra::Async::Test
     # Executes the pending asynchronous blocks, required for the
     # aget/apost/etc blocks to run.
     def async_continue
-      while b = app.options.async_schedules.shift
+      while b = app.settings.async_schedules.shift
         b.call
       end
     end


### PR DESCRIPTION
We needed to alert Airbrake of exceptions that occurred in async requests, which the regular error handling methods weren't catching.

The DSL can be used like so:

``` ruby
aerror do |e|
   HoptoadNotifier.notify error_class: e.class.to_s,
     error_message: e.message, 
     parameters: params, 
     session: env, 
     backtrace: e.backtrace

  status 500
  body e.message
end
```
