### PR TITLE
Add async versions of patch, link, and unlink

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,5 +19,4 @@ Hoe.spec 'async_sinatra' do
   self.extra_rdoc_files = FileList["**/*.rdoc"]
   self.history_file     = "CHANGELOG.rdoc"
   self.readme_file      = "README.rdoc"
-  self.rubyforge_name   = 'libraggi'
 end

--- a/lib/sinatra/async.rb
+++ b/lib/sinatra/async.rb
@@ -58,6 +58,13 @@ module Sinatra #:nodoc:
     def ahead(path, opts={}, &bk); aroute 'HEAD', path, opts, &bk; end
     # See #aget
     def aoptions(path, opts={}, &bk); aroute 'OPTIONS', path, opts, &bk; end
+    # See #aget
+    def apatch(path, opts={}, &bk); aroute 'PATCH', path, opts, &bk; end
+    # See #aget
+    def alink(path, opts={}, &bk); aroute 'LINK', path, opts, &bk; end
+    # See #aget
+    def aunlink(path, opts={}, &bk); aroute 'UNLINK', path, opts, &bk; end
+
 
     private
     def aroute(verb, path, opts = {}, &block) #:nodoc:


### PR DESCRIPTION
Sinatra now supports patch, link, and unlink. async_sinatra should do so as well.

This follows the existing routing and naming converting, even though 'aunlink' looks super ugly to me.

Many of these verbs are lesser used, but there's no reason why async_sinatra shouldn't support them.

Since the current tests only test for aget, i didn't see a point in updating for these.