### PR TITLE
Allow consecutive aget/apost/etc requests

### DIFF
--- a/async_sinatra.gemspec
+++ b/async_sinatra.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rack>, [">= 1.4.1"])
       s.add_runtime_dependency(%q<sinatra>, [">= 1.3.2"])
+      s.add_development_dependency(%q<rack-test>, ["~> 0.6.3"])
       s.add_development_dependency(%q<minitest>, ["~> 5.6"])
       s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_development_dependency(%q<hoe-doofus>, [">= 1.0"])

--- a/lib/sinatra/async/test.rb
+++ b/lib/sinatra/async/test.rb
@@ -46,6 +46,10 @@ class Sinatra::Async::Test
       @after_request.each { |hook| hook.call }
       @last_response
     end
+
+    def reset_last_response
+      @last_response = nil
+    end
   end
 
   module Methods
@@ -54,6 +58,7 @@ class Sinatra::Async::Test
     %w(get put post delete head options).each do |m|
       eval <<-RUBY, binding, __FILE__, __LINE__ + 1
       def a#{m}(*args)
+        rack_mock_session.reset_last_response
         #{m}(*args)
         assert_async
         async_continue

--- a/test/test_async.rb
+++ b/test/test_async.rb
@@ -282,4 +282,10 @@ class TestSinatraAsync < MiniTest::Unit::TestCase
     assert_equal 'test', last_response.body
   end
 
+  def test_two_requests
+    aget '/hello'
+    assert last_response.ok?
+    aget '/302'
+    assert_equal 302, last_response.status
+  end
 end


### PR DESCRIPTION
I need to do multiple async requests for an integration test-- a call to create a resource, and then one to fetch it, to ensure the fetch code is working correctly. I could manually shove the resource into a database, and then fetch it, but it seems wasteful when I have a perfectly good API call to create it already.

This PR resets the `@last_response` in `Sinatra::Async::Test::AsyncSession` every time an `aget`/`apost`/`awhatever` call is made. I don't use the explicit calls to `assert_async` and `assert_continue`, so I'm not sure what a good API for those is.