### PR TITLE
Fix multiple calls to `async.callback` when calling `ahalt` with body

### DIFF
--- a/lib/sinatra/async.rb
+++ b/lib/sinatra/async.rb
@@ -87,7 +87,7 @@ module Sinatra #:nodoc:
       # Send the given body or block as the final response to the asynchronous 
       # request.
       def body(value = nil)
-        if @async_running && (value || block_given?)
+        if @async_running
           if block_given?
             super { async_handle_exception { yield } }
           else
@@ -100,8 +100,8 @@ module Sinatra #:nodoc:
 
           # Taken from Base#call
           unless @response['Content-Type']
-            if Array === body and body[0].respond_to? :content_type
-              content_type body[0].content_type
+            if Array === response.body and response.body[0].respond_to? :content_type
+              content_type response.body[0].content_type
             else
               content_type :html
             end
@@ -114,7 +114,7 @@ module Sinatra #:nodoc:
           result[-1] = [] if request.head?
 
           request.env['async.callback'][ result ]
-          body
+          response.body
         else
           super
         end
@@ -188,7 +188,6 @@ module Sinatra #:nodoc:
       def ahalt(*args)
         invoke { halt(*args) }
         invoke { error_block! response.status }
-        body response.body
       end
 
       # The given block will be executed if the user closes the connection


### PR DESCRIPTION
This fixes an issue where the callback would be called multiple times when calling `ahalt` with a body like so:

```ruby
ahalt 404, 'Thing not found'
```

The problem is apparent when a rack middleware overrides the callback to perform it's own work:

```ruby
def call(env)
  callback = env['async.callback']

  env['async.callback'] = Proc.new do |response|
    puts 'Calling callback!'
    callback.call(response)
  end

  @app.call(env)
end
```

This change removes the manual call to `#body` as `#halt` will automatically do that for you.

It also removes what seems to me like a typo (referencing `#body` instead of `response.body`) which would result in a recursive call to `#body`, and fall through to the else block which would call the super implementation (the default implementation in Sinatra).