### PR TITLE
Add apatch to Sinatra::Async::Test::Methods

### DIFF
--- a/lib/sinatra/async/test.rb
+++ b/lib/sinatra/async/test.rb
@@ -55,7 +55,7 @@ class Sinatra::Async::Test
   module Methods
     include Rack::Test::Methods
 
-    %w(get put post delete head options).each do |m|
+    %w(get put post delete head options patch).each do |m|
       eval <<-RUBY, binding, __FILE__, __LINE__ + 1
       def a#{m}(*args)
         rack_mock_session.reset_last_response

--- a/test/test_async.rb
+++ b/test/test_async.rb
@@ -136,6 +136,10 @@ class TestSinatraAsync < MiniTest::Unit::TestCase
       async_schedule { ahalt 404, 'halted' }
     end
 
+    apatch '/patch' do
+      body { "apatch #{request.body.read}" }
+    end
+
     # Defeat the test environment semantics, ensuring we actually follow the
     # non-test branch of async_schedule. You would normally just call
     # async_schedule in user apps, and use test helpers appropriately.
@@ -322,5 +326,11 @@ class TestSinatraAsync < MiniTest::Unit::TestCase
     aget '/halt-with-body'
     assert_equal 'halted', last_response.body
     assert_equal start + 1, CallbackCounter.count
+  end
+
+  def test_apatch
+    apatch "/patch", "body for apatch", { "CONTENT_TYPE" => "text/plain" }
+    assert_equal 200, last_response.status
+    assert_equal "apatch body for apatch", last_response.body
   end
 end


### PR DESCRIPTION
* This is just a missing test method that is available in
  Rack::Test::Methods but without an async version here.